### PR TITLE
Fix for the folder filters (common for C++ projects)

### DIFF
--- a/Source/TemplateFilemanager.CS.ttinclude
+++ b/Source/TemplateFilemanager.CS.ttinclude
@@ -1062,7 +1062,17 @@ public class VSHelper
 		if (item.Properties == null)
 			return null;
 
-		return item.Properties.Item("FullPath").Value.ToString();
+		string fullPath;
+		try
+		{
+			fullPath = item.Properties.Item("FullPath").Value.ToString();
+		}
+		catch
+		{
+			return null;
+		}		
+
+		return fullPath;		
 	}
 
 	public static IEnumerable<EnvDTE.ProjectItem> GetAllSolutionItems(EnvDTE.DTE dte)


### PR DESCRIPTION
My solution has some CLR C++ projects. Those projects contain Source Files and Header Files folders. Those folders are filter folders and don't have FullPath property.

This pull request addresses this issue.