### PR TITLE
Obtain RCW 

### DIFF
--- a/Source/VsAutomationHelper.CS.ttinclude
+++ b/Source/VsAutomationHelper.CS.ttinclude
@@ -156,7 +156,7 @@ public class DteHelper
 		if (hostServiceProvider != null)
 		{
 			dte = hostServiceProvider.
-				GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+				GetCOMService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
 		}
 
 		return dte;


### PR DESCRIPTION
GetService acquires  a proxy through IServiceProvider, and causes serialization issues across app domain. For example, attempting to write to active VS Window through the DTE object creates exception.  

The GetCOMService extension method returns RCW to marshal calls to the DTE COM object, and is the recommended method by Microsoft.